### PR TITLE
Add support for hashing pod annotations within Deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,10 @@ publish-all: $(addprefix publish-,$(functions))
 
 .PHONY: build-%
 build-%:
-	@$(call banner,Building Kpt function seek/$*:$(VERSION))
+	@$(call banner,Building Kpt function seek/kpt-$*:$(VERSION))
 	docker build . -t seek/kpt-$*:$(VERSION) --build-arg FUNCTION=$*
 
 .PHONY: publish-%
 publish-%: build-%
-	@$(call banner,Publishing Kpt function seek/$*:$(VERSION))
+	@$(call banner,Publishing Kpt function seek/kpt-$*:$(VERSION))
 	docker push seek/kpt-$*:$(VERSION)

--- a/README.md
+++ b/README.md
@@ -2,3 +2,59 @@
 
 This repository provides [Kpt functions](https://googlecontainertools.github.io/kpt/guides/producer/functions)
 that are used to extend Kpt's functionality.
+
+## Function library
+
+### hash-dependency
+
+A common Kubernetes pattern is to have a workload resource (`Deployment`, `StatefulSet`, `DaemonSet` etc.) that mounts
+a `ConfigMap` resource which contains configuration. Frequently, we need to force this workload to restart in order
+for the config changes to take effect. A nice way of achieving this is to cause a change in the configuration resource
+to trigger a change in the workload resource's definition, which causes Kubernetes to replace the workload, forcing it
+to reload config.
+
+This function allows you to designate resources as 'dependencies' via an annotation. When the function is executed,
+the contents of the 'dependency' is hashed, with this hash added as an annotation. When the contents of the 'dependency'
+change, so will the hash, triggering a workload replacement.
+
+See the [README](cmd/hash-dependency/README.md) for usage instructions.
+
+### token-replace
+
+Application authors attempting to adapt existing software to Kubernetes may not have gone to the effort of creating a
+CRD to configure their application. Usually, this manifests as some sort of bespoke configuration file that is expected
+to be passed to the application via a mounted `ConfigMap`. This doesn't work well with `kpt`, because `kpt` is incapable
+of setting values inside of a YAML literal, beacuse there is no way to escape the YAML literal in order to place the
+required `# {"kpt-set":"my-variable"}` comment.
+
+This function allows targeted token replacement with in a `ConfigMap`, in order to address this common use-case.
+
+See the [README](cmd/token-replace/README.md) for usage instructions.
+
+## Repo layout
+
+To create a new function, create a new subfolder under the [cmd]() directory. Subfolders of this directory will be
+discovered automatically by the Makefile eg. for building or publishing Docker images.
+
+## Make targets
+
+### `make test`
+
+Runs unit tests
+
+### `make build-<function-name>`
+
+Builds a Docker image out of the function at `cmd/<function-name>`, tagged as `seek/kpt-<function-name>:$(VERSION)`.
+If the `VERSION` variable is unset, its value defaults to `latest`.
+
+### `make build-all`
+
+Runs `make build-<function-name>` against all functions found in the [cmd]() directory.
+
+### `make publish-<function-name>`
+
+Pushes the Docker image build by `make build-<function-name>`.
+
+### `make publish-all`
+
+Runs `make publish-<function-name>` against all functions found in the [cmd]() directory.

--- a/cmd/hash-dependency/README.md
+++ b/cmd/hash-dependency/README.md
@@ -18,40 +18,6 @@ Example file
 
 ```yaml
 apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: example
-  namespace: example
-  annotations:
-    kpt.seek.com/hash-dependency/config-map: ConfigMap/my-config-map
-spec:
-...
-```
-
-Syntax is `kpt.seek.com/hash-dependency<free-text>: <kind>/<name>`.
-Replace `<free-text>` with something describing what the dependency represents.
-This is optional, but is necessary when you want to hash multiple files, so that the annotation keys do not collide.
-The reference resource must be in the same namespace as the annotated resource.
-
-After adding hash
-
-```yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: example
-  namespace: example
-  annotations:
-    kpt.seek.com/hash-dependency/config-map: ConfigMap/my-config-map
-    ConfigMap/my-config-map: abcdef12345689
-spec:
-...
-```
-
-Hashing also works inside of a PodSpec in Deployments and DaemonSets, for example:
-
-```yaml
-apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: my-deployment
@@ -64,7 +30,12 @@ spec:
 ...
 ```
 
-will hash to:
+Syntax is `kpt.seek.com/hash-dependency<free-text>: <kind>/<name>`.
+Replace `<free-text>` with something describing what the dependency represents.
+This is optional, but is necessary when you want to hash multiple files, so that the annotation keys do not collide.
+The reference resource must be in the same namespace as the annotated resource.
+
+After adding hash
 
 ```yaml
 apiVersion: apps/v1
@@ -81,5 +52,6 @@ spec:
 ...
 ```
 
-This allows you to have a pod as part of a deployment that depends on another resource, with the pods being updated
-when the hash of the dependant resource changes.
+This function will search for `PodTemplates` inside of `Deployemnts`, `ReplicaSets`, `StatefulSets` and `DaemonSets`.
+This function will also find `hash-dependency` annotations in top level `metadata` blocks on arbitrary resources, but
+this use case is less common.

--- a/cmd/hash-dependency/README.md
+++ b/cmd/hash-dependency/README.md
@@ -18,7 +18,7 @@ Example file
 
 ```yaml
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: example
   namespace: example
@@ -37,7 +37,7 @@ After adding hash
 
 ```yaml
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: example
   namespace: example
@@ -47,3 +47,39 @@ metadata:
 spec:
 ...
 ```
+
+Hashing also works inside of a Deployment PodSpec, for example:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+  namespace: example
+spec:
+  template:
+    metadata:
+      annotations:
+        kpt.seek.com/hash-dependency/config-map: ConfigMap/my-config-map
+...
+```
+
+will hash to:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+  namespace: example
+spec:
+  template:
+    metadata:
+      annotations:
+        kpt.seek.com/hash-dependency/config-map: ConfigMap/my-config-map
+        ConfigMap/my-config-map: abcdef12345689
+...
+```
+
+This allows you to have a pod as part of a deployment that depends on another resource, with the pods being updated
+when the hash of the dependant resource changes.

--- a/cmd/hash-dependency/README.md
+++ b/cmd/hash-dependency/README.md
@@ -48,7 +48,7 @@ spec:
 ...
 ```
 
-Hashing also works inside of a Deployment PodSpec, for example:
+Hashing also works inside of a PodSpec in Deployments and DaemonSets, for example:
 
 ```yaml
 apiVersion: apps/v1

--- a/cmd/hash-dependency/main.go
+++ b/cmd/hash-dependency/main.go
@@ -10,9 +10,9 @@ import (
 func main() {
 	config := fns.HashDependencyConfig{}
 	resourceList := &framework.ResourceList{FunctionConfig: &config}
-	dependencyHasher := fns.DependencyHasher{ResourceListItems: resourceList.Items}
 
 	cmd := framework.Command(resourceList, func() error {
+    dependencyHasher := fns.DependencyHasher{ResourceListItems: resourceList.Items}
 		for i := range resourceList.Items {
 			if err := resourceList.Items[i].PipeE(&dependencyHasher); err != nil {
 				return err

--- a/pkg/fns/hash_dependency.go
+++ b/pkg/fns/hash_dependency.go
@@ -12,6 +12,8 @@ const hashDependencyAnnotationPrefix string = "kpt.seek.com/hash-dependency"
 var podSpecKinds = [...]string{
   "Deployment",
   "DaemonSet",
+  "ReplicaSet",
+  "StatefulSet",
 }
 
 type HashDependencyConfig struct {

--- a/pkg/fns/hash_dependency.go
+++ b/pkg/fns/hash_dependency.go
@@ -31,7 +31,7 @@ func (dh *DependencyHasher) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
 
 	for k, v := range meta.Annotations {
 		if strings.HasPrefix(k, hashDependencyAnnotationPrefix) {
-      fmt.Fprintf(os.Stderr, "hashing dependency for %s/%s", meta.Namespace, meta.Name)
+      fmt.Fprintf(os.Stderr, "hashing dependency for %s/%s\n", meta.Namespace, meta.Name)
 			err := dh.hashDependency(rn, meta.Namespace, v)
 			if err != nil {
 				return rn, err
@@ -58,7 +58,7 @@ func (dh *DependencyHasher) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
     }
     for k, v := range podMeta.Annotations {
       if strings.HasPrefix(k, hashDependencyAnnotationPrefix) {
-        fmt.Fprintf(os.Stderr, "hashing pod dependency for %s/%s", meta.Namespace, meta.Name)
+        fmt.Fprintf(os.Stderr, "hashing pod dependency for %s/%s\n", meta.Namespace, meta.Name)
         err := dh.hashDependency(podSpec, meta.Namespace, v)
         if err != nil {
           return rn, err

--- a/pkg/fns/hash_dependency.go
+++ b/pkg/fns/hash_dependency.go
@@ -15,7 +15,6 @@ var podSpecKinds = [...]string{
 }
 
 type HashDependencyConfig struct {
-	Spec Spec `yaml:"spec,omitempty"`
 }
 
 type DependencyHasher struct {

--- a/pkg/fns/hash_dependency.go
+++ b/pkg/fns/hash_dependency.go
@@ -1,12 +1,11 @@
 package fns
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"fmt"
-  "os"
+  "crypto/sha256"
+  "encoding/hex"
+  "fmt"
   "sigs.k8s.io/kustomize/kyaml/yaml"
-	"strings"
+  "strings"
 )
 
 const hashDependencyAnnotationPrefix string = "kpt.seek.com/hash-dependency"
@@ -31,7 +30,6 @@ func (dh *DependencyHasher) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
 
 	for k, v := range meta.Annotations {
 		if strings.HasPrefix(k, hashDependencyAnnotationPrefix) {
-      fmt.Fprintf(os.Stderr, "hashing dependency for %s/%s\n", meta.Namespace, meta.Name)
 			err := dh.hashDependency(rn, meta.Namespace, v)
 			if err != nil {
 				return rn, err
@@ -58,7 +56,6 @@ func (dh *DependencyHasher) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
     }
     for k, v := range podMeta.Annotations {
       if strings.HasPrefix(k, hashDependencyAnnotationPrefix) {
-        fmt.Fprintf(os.Stderr, "hashing pod dependency for %s/%s\n", meta.Namespace, meta.Name)
         err := dh.hashDependency(podSpec, meta.Namespace, v)
         if err != nil {
           return rn, err

--- a/pkg/fns/hash_dependency.go
+++ b/pkg/fns/hash_dependency.go
@@ -4,7 +4,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"sigs.k8s.io/kustomize/kyaml/yaml"
+  "os"
+  "sigs.k8s.io/kustomize/kyaml/yaml"
 	"strings"
 )
 
@@ -30,6 +31,7 @@ func (dh *DependencyHasher) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
 
 	for k, v := range meta.Annotations {
 		if strings.HasPrefix(k, hashDependencyAnnotationPrefix) {
+      fmt.Fprintf(os.Stderr, "hashing dependency for %s/%s", meta.Namespace, meta.Name)
 			err := dh.hashDependency(rn, meta.Namespace, v)
 			if err != nil {
 				return rn, err
@@ -56,6 +58,7 @@ func (dh *DependencyHasher) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
     }
     for k, v := range podMeta.Annotations {
       if strings.HasPrefix(k, hashDependencyAnnotationPrefix) {
+        fmt.Fprintf(os.Stderr, "hashing pod dependency for %s/%s", meta.Namespace, meta.Name)
         err := dh.hashDependency(podSpec, meta.Namespace, v)
         if err != nil {
           return rn, err

--- a/pkg/fns/hash_dependency_test.go
+++ b/pkg/fns/hash_dependency_test.go
@@ -286,6 +286,171 @@ functionConfig:
   spec: {}
 `,
 		},
+    {
+      testCase: "Hashes annotations within a Deployment pod spec",
+      input: `
+apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: example
+    namespace: example
+  spec:
+    template:
+      metadata:
+        annotations:
+          kpt.seek.com/hash-dependency/config-map: ConfigMap/my-config-map
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: my-config-map
+    namespace: example
+  data: {}
+- apiVersion: custom-namespace.seek.com/v1
+  kind: AnotherType
+  metadata:
+    name: another-type
+    namespace: example
+  data: {}
+
+functionConfig:
+  apiVersion: kpt.seek.com/v1alpha1
+  kind: HashDependency
+  metadata:
+    name: hash-dependency
+    annotations:
+      config.kubernetes.io/function: |
+        container:
+          image: gantry-hash-dependency:latest
+  spec: {}
+`,
+      expectedOutput: `
+apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: example
+    namespace: example
+  spec:
+    template:
+      metadata:
+        annotations:
+          kpt.seek.com/hash-dependency/config-map: ConfigMap/my-config-map
+          ConfigMap/my-config-map: 'dfa6c3c082ad3ee44f29b13328af93f4c00e9438e93f7c8b5a58dd389cd491e6'
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: my-config-map
+    namespace: example
+  data: {}
+- apiVersion: custom-namespace.seek.com/v1
+  kind: AnotherType
+  metadata:
+    name: another-type
+    namespace: example
+  data: {}
+
+functionConfig:
+  apiVersion: kpt.seek.com/v1alpha1
+  kind: HashDependency
+  metadata:
+    name: hash-dependency
+    annotations:
+      config.kubernetes.io/function: |
+        container:
+          image: gantry-hash-dependency:latest
+  spec: {}
+`,
+    },
+    {
+      testCase: "Hashes annotations within a Deployment pod spec and the Deployment metadata",
+      input: `
+apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: example
+    namespace: example
+    annotations:
+      kpt.seek.com/hash-dependency/config-map: ConfigMap/my-config-map
+  spec:
+    template:
+      metadata:
+        annotations:
+          kpt.seek.com/hash-dependency/config-map: ConfigMap/my-config-map
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: my-config-map
+    namespace: example
+  data: {}
+- apiVersion: custom-namespace.seek.com/v1
+  kind: AnotherType
+  metadata:
+    name: another-type
+    namespace: example
+  data: {}
+
+functionConfig:
+  apiVersion: kpt.seek.com/v1alpha1
+  kind: HashDependency
+  metadata:
+    name: hash-dependency
+    annotations:
+      config.kubernetes.io/function: |
+        container:
+          image: gantry-hash-dependency:latest
+  spec: {}
+`,
+      expectedOutput: `
+apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: example
+    namespace: example
+    annotations:
+      kpt.seek.com/hash-dependency/config-map: ConfigMap/my-config-map
+      ConfigMap/my-config-map: 'dfa6c3c082ad3ee44f29b13328af93f4c00e9438e93f7c8b5a58dd389cd491e6'
+  spec:
+    template:
+      metadata:
+        annotations:
+          kpt.seek.com/hash-dependency/config-map: ConfigMap/my-config-map
+          ConfigMap/my-config-map: 'dfa6c3c082ad3ee44f29b13328af93f4c00e9438e93f7c8b5a58dd389cd491e6'
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: my-config-map
+    namespace: example
+  data: {}
+- apiVersion: custom-namespace.seek.com/v1
+  kind: AnotherType
+  metadata:
+    name: another-type
+    namespace: example
+  data: {}
+
+functionConfig:
+  apiVersion: kpt.seek.com/v1alpha1
+  kind: HashDependency
+  metadata:
+    name: hash-dependency
+    annotations:
+      config.kubernetes.io/function: |
+        container:
+          image: gantry-hash-dependency:latest
+  spec: {}
+`,
+    },
 	}
 
 	for index := range testCases {


### PR DESCRIPTION
This allows for dependency hashing to work inside of a deployment pod
template. This is a common use case, where you want pods to be
re-created when a config map is updated. I _think_ this is the only way
to achieve this, as updating a deployment's annotations would not cause
Pods to be recreated.

As part of this, it's necessary to add the namespace parameter to the
hashDependency function, because this information isn't available in the
metadata that we extract from the PodSpec. This feels recursive, and we
could avoid the duplicated code by recursing on the Filter function, but
the issue there is that we lose the namespace when we recurse, which is
crucial for making sure we don't match resources across namespaces. We
could embed the namespace in the metadata and remove it again later, but
it felt simplest to just duplicate the code. We can come up with a more
elegant solution if we find more special cases.