### PR TITLE
Restrict workflow runs to master branch

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,11 @@
 name: Lint, test, build functions and publish to DockerHub
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   lint:
     name: lint


### PR DESCRIPTION
This should avoid the current scenario where we have duplicate workflow
runs on PRs, because they are both a 'push' and a 'pull_request'