### PR TITLE
Support custom delimiters

### DIFF
--- a/cmd/sync/README.md
+++ b/cmd/sync/README.md
@@ -294,3 +294,73 @@ data:
 ```
 
 Note: It's currently not possible to use Kpt substitutions in templates. This issue is tracked as [issue #15](https://github.com/seek-oss/kpt-functions/issues/15)
+
+### Custom template delimiters
+
+The templating function also supports setting of custom delimiters.
+This is useful if you want to do some templating on a file that already uses go template syntax.
+Using standard delimiters will cause this to error, as our templating function only offers a limited number of
+functions.
+
+Custom delimiters can be set using the `$kpt-template-left-delimiter` and `$kpt-template-right-delimiter` parameters,
+as per the example below:
+```yaml
+# configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: some-name
+  namespace: some-namespace
+data:
+  # {"$kpt-template":"true","$kpt-template-left-delimiter":"${","$kpt-template-right-delimiter":"}$"}
+  my-data.json: |
+    ${render "my-template" "foo" "bar"}$
+
+# config/development/ap-southeast-2/a/packages.yaml
+apiVersion: kpt.seek.com/v1alpha1
+kind: ClusterPackages
+metadata:
+  name: development-a-ap-southeast-2
+spec:
+  baseDir: config/development/ap-southeast-2/a/packages
+  packages:
+    - name: some-application
+      git:
+        repo: git@github.com:seek-oss/packages.git
+        directory: some-application
+        ref: 5fc702d3dd0f46509283cb0bcc4a3327d1ee8b1
+  variables:
+    - name: region
+      value: ap-southeast-2
+    - name: my-template
+      value: |
+        {
+          "region": "${value "region"}$",
+          "first-arg": "${args 0}$",
+          "second-arg": "${args 1}$"
+          "some-other-key": "{{ this will not be interpreted as a go template }}"
+        }
+```
+
+This would be rendered as:
+```yaml
+# configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: some-name
+  namespace: some-namespace
+data:
+  # {"$kpt-template":"true"}
+  my-data.json: |
+    {
+      "region": "ap-southeast-2",
+      "first-arg": "foo",
+      "second-arg": "bar"
+      "some-other-key": "{{ this will not be interpreted as a go template }}"
+    }
+```
+
+As you can see, the `some-other-key` value has not been interpreted as a go template.
+Without custom delimiters, attempting to render this template would error with `function "this" is not defined`,
+as the first word inside the `{{ }}` was interpreted as a function.

--- a/cmd/sync/README.md
+++ b/cmd/sync/README.md
@@ -364,3 +364,6 @@ data:
 As you can see, the `some-other-key` value has not been interpreted as a go template.
 Without custom delimiters, attempting to render this template would error with `function "this" is not defined`,
 as the first word inside the `{{ }}` was interpreted as a function.
+
+Setting of alternate delimiters is 'sticky', in the sense that once you have set alternate delimiters, they will apply
+recursively for any template rendering, and they cannot be reset.

--- a/pkg/filters/template_testdata/alternate-delimiters/expected.yaml
+++ b/pkg/filters/template_testdata/alternate-delimiters/expected.yaml
@@ -1,0 +1,91 @@
+apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: kpt.dev/v1alpha1
+  kind: Kptfile
+  metadata:
+    name: test
+  openAPI:
+    definitions:
+      io.k8s.cli.setters.account-id:
+        type: string
+        x-k8s-cli:
+          setter:
+            name: account-id
+            value: 111222333444
+      io.k8s.cli.setters.region:
+        type: string
+        x-k8s-cli:
+          setter:
+            name: region
+            value: ap-southeast-1
+      io.k8s.cli.setters.domain-names:
+        type: array
+        items:
+          type: string
+        x-k8s-cli:
+          setter:
+            name: domain-names
+            listValues:
+            - "example.com"
+            - "dead.beef"
+      io.k8s.cli.setters.oidc-provider-id:
+        type: string
+        x-k8s-cli:
+          setter:
+            name: oidc-provider-id
+            value: ABCDEFG
+      io.k8s.cli.setters.irsa-policy:
+        type: string
+        x-k8s-cli:
+          setter:
+            name: simple-template
+            value: |-
+              {
+                "SomeField": {{i want this unchanged}}
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Principal": {
+                      "Federated": 'arn:aws:iam::${value "account-id"}$:oidc-provider/oidc.eks.${value "region"}$.amazonaws.com/id/${value "oidc-provider-id"}$'
+                    },
+                    "Action": "sts:AssumeRoleWithWebIdentity",
+                    "Condition": {
+                      "StringEquals": {
+                        "oidc.eks.${value "region"}$.amazonaws.com/id/${value "oidc-provider-id"}$:sub": "system:serviceaccount:${args 0}$:${if eq nargs 1}$${args 0}$${else}$${args 1}$${end}$"
+                      }
+                    }
+                  }
+                ]
+              }
+- apiVersion: identity.aws.crossplane.io/v1beta1
+  kind: IAMRole
+  metadata:
+    name: cert-manager-role # {"$kpt-set":"role-name"}
+    namespace: cert-manager
+  spec:
+    forProvider:
+      # {"$kpt-template":"true","$kpt-template-left-delimiter":"${","$kpt-template-right-delimiter":"}$"}
+      assumeRolePolicyDocument: |
+        {
+          "SomeField": {{i want this unchanged}}
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": 'arn:aws:iam::111222333444:oidc-provider/oidc.eks.ap-southeast-1.amazonaws.com/id/ABCDEFG'
+              },
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Condition": {
+                "StringEquals": {
+                  "oidc.eks.ap-southeast-1.amazonaws.com/id/ABCDEFG:sub": "system:serviceaccount:cert-manager:cert-manager"
+                }
+              }
+            }
+          ]
+        }
+    reclaimPolicy: Delete
+    providerRef:
+      name: aws-provider

--- a/pkg/filters/template_testdata/alternate-delimiters/input.yaml
+++ b/pkg/filters/template_testdata/alternate-delimiters/input.yaml
@@ -1,0 +1,74 @@
+apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: kpt.dev/v1alpha1
+  kind: Kptfile
+  metadata:
+    name: test
+  openAPI:
+    definitions:
+      io.k8s.cli.setters.account-id:
+        type: string
+        x-k8s-cli:
+          setter:
+            name: account-id
+            value: 111222333444
+      io.k8s.cli.setters.region:
+        type: string
+        x-k8s-cli:
+          setter:
+            name: region
+            value: ap-southeast-1
+      io.k8s.cli.setters.domain-names:
+        type: array
+        items:
+          type: string
+        x-k8s-cli:
+          setter:
+            name: domain-names
+            listValues:
+              - "example.com"
+              - "dead.beef"
+      io.k8s.cli.setters.oidc-provider-id:
+        type: string
+        x-k8s-cli:
+          setter:
+            name: oidc-provider-id
+            value: ABCDEFG
+      io.k8s.cli.setters.irsa-policy:
+        type: string
+        x-k8s-cli:
+          setter:
+            name: simple-template
+            value: |-
+              {
+                "SomeField": {{i want this unchanged}}
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Principal": {
+                      "Federated": 'arn:aws:iam::${value "account-id"}$:oidc-provider/oidc.eks.${value "region"}$.amazonaws.com/id/${value "oidc-provider-id"}$'
+                    },
+                    "Action": "sts:AssumeRoleWithWebIdentity",
+                    "Condition": {
+                      "StringEquals": {
+                        "oidc.eks.${value "region"}$.amazonaws.com/id/${value "oidc-provider-id"}$:sub": "system:serviceaccount:${args 0}$:${if eq nargs 1}$${args 0}$${else}$${args 1}$${end}$"
+                      }
+                    }
+                  }
+                ]
+              }
+- apiVersion: identity.aws.crossplane.io/v1beta1
+  kind: IAMRole
+  metadata:
+    name: cert-manager-role # {"$kpt-set":"role-name"}
+    namespace: cert-manager
+  spec:
+    forProvider:
+      # {"$kpt-template":"true","$kpt-template-left-delimiter":"${","$kpt-template-right-delimiter":"}$"}
+      assumeRolePolicyDocument: |
+        ${render "simple-template" "cert-manager"}$
+    reclaimPolicy: Delete
+    providerRef:
+      name: aws-provider


### PR DESCRIPTION
This adds support for custom delimiters. This allows us to use the templating functionality of the sync function in conjunction with the go templating used by other software and systems. Specifically, this will allow us to template some fields of an alertmanager config, while others are handled by alertmanager itself.