### PR TITLE
Change template rendering behaviour to be less 'sticky'

### DIFF
--- a/cmd/sync/testdata/template-after-literal/expected.yaml
+++ b/cmd/sync/testdata/template-after-literal/expected.yaml
@@ -1,0 +1,36 @@
+apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: kpt.dev/v1alpha1
+  kind: Kptfile
+  metadata:
+    name: sample
+    annotations:
+      config.kubernetes.io/path: sample/Kptfile
+  packageMetadata:
+    shortDescription: sample description
+  openAPI:
+    definitions:
+      io.k8s.cli.setters.template:
+        x-k8s-cli:
+          setter:
+            name: template
+            value: |
+              ! some string
+            setBy: cluster-override
+            isSet: true
+- apiVersion: v1
+  kind: Test
+  metadata:
+    name: test
+    namespace: test
+    annotations:
+      config.kubernetes.io/path: sample/test.yaml
+  spec:
+    # {"$kpt-template":"true"}
+    some_value: |+
+      ! some string
+    something_else: '{{ $foo.bar this should not be templated }}'
+functionConfig:
+  kind: ConfigMap
+  data: {}

--- a/cmd/sync/testdata/template-after-literal/expected.yaml
+++ b/cmd/sync/testdata/template-after-literal/expected.yaml
@@ -30,6 +30,7 @@ items:
     # {"$kpt-template":"true"}
     some_value: |+
       ! some string
+
     something_else: '{{ $foo.bar this should not be templated }}'
 functionConfig:
   kind: ConfigMap

--- a/cmd/sync/testdata/template-after-literal/input.yaml
+++ b/cmd/sync/testdata/template-after-literal/input.yaml
@@ -1,0 +1,20 @@
+apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+  - apiVersion: kpt.seek.com/v1alpha1
+    kind: ClusterPackages
+    metadata:
+      name: sample
+    spec:
+      baseDir: .
+      packages:
+        - name: sample
+          local:
+            directory: sample
+      variables:
+        - name: template
+          value: |
+            ! some string
+functionConfig:
+  kind: ConfigMap
+  data: {}

--- a/cmd/sync/testdata/template-after-literal/sample/Kptfile
+++ b/cmd/sync/testdata/template-after-literal/sample/Kptfile
@@ -1,0 +1,13 @@
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: sample
+packageMetadata:
+  shortDescription: sample description
+openAPI:
+  definitions:
+    io.k8s.cli.setters.template:
+      x-k8s-cli:
+        setter:
+          name: template
+          value: placeholder

--- a/cmd/sync/testdata/template-after-literal/sample/README.md
+++ b/cmd/sync/testdata/template-after-literal/sample/README.md
@@ -1,0 +1,29 @@
+# sample
+
+## Description
+sample description
+
+## Usage
+
+### Fetch the package
+`kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] sample`
+Details: https://googlecontainertools.github.io/kpt/reference/pkg/get/
+
+### View package content
+`kpt cfg tree sample`
+Details: https://googlecontainertools.github.io/kpt/reference/cfg/tree/
+
+### List setters
+`kpt cfg list-setters sample`
+Details: https://googlecontainertools.github.io/kpt/reference/cfg/list-setters/
+
+### Set a value
+`kpt cfg set sample NAME VALUE`
+Details: https://googlecontainertools.github.io/kpt/reference/cfg/set/
+
+### Apply the package
+```
+kpt live init sample
+kpt live apply sample --reconcile-timeout=2m --output=table
+```
+Details: https://googlecontainertools.github.io/kpt/reference/live/

--- a/cmd/sync/testdata/template-after-literal/sample/test.yaml
+++ b/cmd/sync/testdata/template-after-literal/sample/test.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Test
+metadata:
+  name: test
+  namespace: test
+spec:
+  # {"$kpt-template":"true"}
+  some_value: |
+    {{render "template"}}
+  something_else: '{{ $foo.bar this should not be templated }}'

--- a/pkg/filters/template.go
+++ b/pkg/filters/template.go
@@ -127,7 +127,7 @@ func (f *TemplateFilter) render(rn *yaml.RNode, exec executeTemplate, templatePa
 	switch rn.YNode().Kind {
 	case yaml.MappingNode:
 		return rn.VisitFields(func(rn *yaml.MapNode) error {
-			templateParameters.templatingEnabled = templateParameters.templatingEnabled || f.hasEnabledTemplating(rn.Key)
+			templateParameters.templatingEnabled = f.hasEnabledTemplating(rn.Key)
 			if templateParameters.leftDelimiter == defaultLeftDelimiter {
 				templateParameters.leftDelimiter = f.getDelimiter(rn.Key, left)
 			}

--- a/pkg/filters/template_testdata/simple/expected.yaml
+++ b/pkg/filters/template_testdata/simple/expected.yaml
@@ -34,9 +34,11 @@ items:
   metadata:
     name: example1
     namespace: example
-  spec: # {"$kpt-template":"true"}
+  spec:
     foo:
+      # {"$kpt-template":"true"}
       bar: 'ap-southeast-1'
+      # {"$kpt-template":"true"}
       baz:
       - '111222333444'
       - 'dead.beef,example.com'

--- a/pkg/filters/template_testdata/simple/input.yaml
+++ b/pkg/filters/template_testdata/simple/input.yaml
@@ -35,9 +35,11 @@ items:
   metadata:
     name: example1
     namespace: example
-  spec: # {"$kpt-template":"true"}
+  spec:
     foo:
+      # {"$kpt-template":"true"}
       bar: '{{value "region"}}'
+      # {"$kpt-template":"true"}
       baz:
         - '{{value "account-id"}}'
         - '{{value "domain-names" | sortAlpha | join ","}}'


### PR DESCRIPTION
Template rendering used to be a little unpredictable. The existing behaviour was that if any child node of a mapping node had a head comment that enabled templating, it would then be enabled for the rest of the processing of the mapping node. This is both error prone, surprising, and confusing. e.g. if the second child of a mapping node has a head comment that has template :true, the nodes after will also have templating, but the first node will not.

Now, we check each child node for the template head comment.