### PR TITLE
fix an issue where switching between commits might cause unstaged changes

### DIFF
--- a/pkg/filters/clusterpackages.go
+++ b/pkg/filters/clusterpackages.go
@@ -292,7 +292,10 @@ func (f *ClusterPackagesFilter) fetchPackage(ctx context.Context, pkg *Package) 
 			return nil, errors.WrapPrefixf(err, "error obtaining worktree for repository %s", pkg.Git.Repo)
 		}
 
-		if err := w.Checkout(&git.CheckoutOptions{Hash: plumbing.NewHash(pkg.Git.Ref)}); err != nil {
+		if err := w.Checkout(&git.CheckoutOptions{
+			Hash:  plumbing.NewHash(pkg.Git.Ref),
+			Force: true,
+		}); err != nil {
 			return nil, errors.WrapPrefixf(err, "error checking out ref %s for repository %s", pkg.Git.Ref, pkg.Git.Repo)
 		}
 


### PR DESCRIPTION
The gantry-state rendering functionality is not working properly after the changes made in https://github.com/SEEK-Jobs/gantry-packages/pull/1181

The root cause of the issue is that during the process of switching between different commits in the packages, there might be some leftover unstaged changes caused by newly added folders or files. In this particular case, the `tools` folder was left hanging, and it prevented Git from checking out another commit.

To resolve this problem, this pull request enables the force mode, which instructs Git to discard any local changes (such as the `tools` folder in this case) and proceed with the checkout.

After applying this fix, the rendering script is once again working properly.